### PR TITLE
empty prefix, allow event instead of cancelling.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,5 +71,11 @@
             <version>1.16.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.geysermc.floodgate</groupId>
+            <artifactId>api</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/pw/chew/customcommandprefix/BrandPluginMessageListener.java
+++ b/src/main/java/pw/chew/customcommandprefix/BrandPluginMessageListener.java
@@ -1,0 +1,26 @@
+package pw.chew.customcommandprefix;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+
+/*
+ * Uses PluginMessageListener to check if Geyser is being used, just in-case
+ * server does not use Floodgate.
+ * 
+ * Credit for this class and implementation: https://github.com/Heath123/debuginfo-be/blob/main/src/main/java/com/gmail/heathmitchell27/debuginfobe/BrandPluginMessageListener.java
+ */
+public class BrandPluginMessageListener implements PluginMessageListener {
+	static HashMap<Player, String> playerBrands = new HashMap<>();
+
+	@Override
+	public void onPluginMessageReceived(String channel, Player p, byte[] msg) {
+		try {
+			playerBrands.put(p, new String(msg, "UTF-8").substring(1));
+		} catch (UnsupportedEncodingException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/pw/chew/customcommandprefix/ChatListener.java
+++ b/src/main/java/pw/chew/customcommandprefix/ChatListener.java
@@ -1,19 +1,14 @@
 package pw.chew.customcommandprefix;
 
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.geysermc.floodgate.api.FloodgateApi;
 
-public class ChatListener implements Listener, PluginMessageListener {
+public class ChatListener implements Listener {
 	private final CustomCommandPrefix plugin;
-	private static HashMap<Player, String> playerBrands = new HashMap<>();
 
 	public ChatListener(CustomCommandPrefix plugin) {
 		this.plugin = plugin;
@@ -23,13 +18,14 @@ public class ChatListener implements Listener, PluginMessageListener {
 	public void onCommand(AsyncPlayerChatEvent event) {
 		Player player = event.getPlayer();
 		String message = event.getMessage();
-
+		
 		//Check if player is not Geyser or Not Floodgate. Example, if player is Geyser and not Floodgate, it will not enter the if statement.
 		//In Conclusion, only java players will be returned and commandprefix only applies to Bedrock Players.
-		if ((playerBrands.get(player) == null || !playerBrands.get(player).equals("Geyser"))
+		if ((BrandPluginMessageListener.playerBrands.get(player) == null || !BrandPluginMessageListener.playerBrands.get(player).equals("Geyser"))
 				&& (!FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId()))) {
 			return;
 		}
+		
 		String prefix = plugin.getConfig().getString("prefix");
 		if (message.startsWith(prefix)) {
 			event.setCancelled(true);
@@ -41,19 +37,6 @@ public class ChatListener implements Listener, PluginMessageListener {
 				return;
 			}
 			Bukkit.getScheduler().runTask(plugin, () -> player.performCommand(message.replace(prefix, "")));
-		}
-	}
-
-	/*
-	 * Uses PluginMessageListener to check if Geyser is being used, just in-case
-	 * server does not use Floodgate.
-	 */
-	@Override
-	public void onPluginMessageReceived(String channel, Player player, byte[] message) {
-		try {
-			playerBrands.put(player, new String(message, "UTF-8").substring(1));
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
 		}
 	}
 }

--- a/src/main/java/pw/chew/customcommandprefix/ChatListener.java
+++ b/src/main/java/pw/chew/customcommandprefix/ChatListener.java
@@ -1,12 +1,19 @@
 package pw.chew.customcommandprefix;
 
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.geysermc.floodgate.api.FloodgateApi;
 
-public class ChatListener implements Listener {
+public class ChatListener implements Listener, PluginMessageListener {
 	private final CustomCommandPrefix plugin;
+	private static HashMap<Player, String> playerBrands = new HashMap<>();
 
 	public ChatListener(CustomCommandPrefix plugin) {
 		this.plugin = plugin;
@@ -14,17 +21,39 @@ public class ChatListener implements Listener {
 
 	@EventHandler
 	public void onCommand(AsyncPlayerChatEvent event) {
+		Player player = event.getPlayer();
+		String message = event.getMessage();
+
+		//Check if player is not Geyser or Not Floodgate. Example, if player is Geyser and not Floodgate, it will not enter the if statement.
+		//In Conclusion, only java players will be returned and commandprefix only applies to Bedrock Players.
+		if ((playerBrands.get(player) == null || !playerBrands.get(player).equals("Geyser"))
+				&& (!FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId()))) {
+			return;
+		}
 		String prefix = plugin.getConfig().getString("prefix");
-		if (event.getMessage().startsWith(prefix)) {
+		if (message.startsWith(prefix)) {
 			event.setCancelled(true);
 			// logic for if prefix is set to be empty in the config, so we
 			// permit command debugging here.
 			if (prefix.isEmpty()) {
-				Bukkit.getScheduler().runTask(plugin, () -> event.getPlayer().performCommand(event.getMessage()));
+				Bukkit.getScheduler().runTask(plugin, () -> player.performCommand(message));
 				event.setCancelled(false);
 				return;
 			}
-			Bukkit.getScheduler().runTask(plugin, () -> event.getPlayer().performCommand(event.getMessage().replace(prefix, "")));
+			Bukkit.getScheduler().runTask(plugin, () -> player.performCommand(message.replace(prefix, "")));
+		}
+	}
+
+	/*
+	 * Uses PluginMessageListener to check if Geyser is being used, just in-case
+	 * server does not use Floodgate.
+	 */
+	@Override
+	public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+		try {
+			playerBrands.put(player, new String(message, "UTF-8").substring(1));
+		} catch (UnsupportedEncodingException e) {
+			e.printStackTrace();
 		}
 	}
 }

--- a/src/main/java/pw/chew/customcommandprefix/ChatListener.java
+++ b/src/main/java/pw/chew/customcommandprefix/ChatListener.java
@@ -6,18 +6,25 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 public class ChatListener implements Listener {
-    private final CustomCommandPrefix plugin;
+	private final CustomCommandPrefix plugin;
 
-    public ChatListener(CustomCommandPrefix plugin) {
-        this.plugin = plugin;
-    }
+	public ChatListener(CustomCommandPrefix plugin) {
+		this.plugin = plugin;
+	}
 
-    @EventHandler
-    public void onCommand(AsyncPlayerChatEvent event) {
-        String prefix = plugin.getConfig().getString("prefix");
-        if (event.getMessage().startsWith(prefix)) {
-            event.setCancelled(true);
-            Bukkit.getScheduler().runTask(plugin, () -> event.getPlayer().performCommand(event.getMessage().replace(prefix, "")));
-        }
-    }
+	@EventHandler
+	public void onCommand(AsyncPlayerChatEvent event) {
+		String prefix = plugin.getConfig().getString("prefix");
+		if (event.getMessage().startsWith(prefix)) {
+			event.setCancelled(true);
+			// logic for if prefix is set to be empty in the config, so we
+			// permit command debugging here.
+			if (prefix.isEmpty()) {
+				Bukkit.getScheduler().runTask(plugin, () -> event.getPlayer().performCommand(event.getMessage()));
+				event.setCancelled(false);
+				return;
+			}
+			Bukkit.getScheduler().runTask(plugin, () -> event.getPlayer().performCommand(event.getMessage().replace(prefix, "")));
+		}
+	}
 }

--- a/src/main/java/pw/chew/customcommandprefix/CustomCommandPrefix.java
+++ b/src/main/java/pw/chew/customcommandprefix/CustomCommandPrefix.java
@@ -1,7 +1,9 @@
 package pw.chew.customcommandprefix;
 
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.Messenger;
 
 public final class CustomCommandPrefix extends JavaPlugin {
     @Override
@@ -12,7 +14,10 @@ public final class CustomCommandPrefix extends JavaPlugin {
         config.addDefault("replace_slash_prefix", false);
         config.options().copyDefaults(true);
         saveDefaultConfig();
-
+        
+        Messenger messenger = Bukkit.getMessenger();
+        messenger.registerIncomingPluginChannel(this, "minecraft:brand", new BrandPluginMessageListener());
+        
         // Register Events
         getServer().getPluginManager().registerEvents(new ChatListener(this), this);
     }


### PR DESCRIPTION
Don't mind the formatting, it looked the same in eclipse and not like this in github and I only used 1 tab.

Previously, if the server owner set the prefix in the config to be empty, no players could send any non-command messages.
This commit fixes that by adding logic for empty prefix for all messages, whether if command or not, are sent and executed.

As a side note, If you try the following to only allow non-commands as messages, and commands as commands:
```
if (prefix.isEmpty()) 
{
	Bukkit.getScheduler().runTask(plugin, () -> { 
	if(!event.getPlayer().performCommand(event.getMessage())) 
	     event.setCancelled(false);
	 });
	return;
}
```
it does not work, and any variation around this does not work, but feel free to try...